### PR TITLE
Update GitHub Actions versions and Sonar scan args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build-analyze:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build and analyze on SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Build and analyze on SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Build and analyze on SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build-analyze.ps1
+++ b/build-analyze.ps1
@@ -23,8 +23,8 @@ $path = "$HOME/.sonar/build-wrapper-win-x86.zip"
 $env:Path += ";$HOME/.sonar/build-wrapper-win-x86"
 
 # Download sonar-scanner
-$path = "$HOME/.sonar/sonar-scanner-cli-$SONAR_SCANNER_VERSION-windows.zip"
-(New-Object System.Net.WebClient).DownloadFile("https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-windows.zip", $path)
+$path = "$HOME/.sonar/sonar-scanner-cli-$SONAR_SCANNER_VERSION-windows-x64.zip"
+(New-Object System.Net.WebClient).DownloadFile("https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-windows-x64.zip", $path)
 [System.IO.Compression.ZipFile]::ExtractToDirectory($path, "$HOME/.sonar")
 $env:Path += ";$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-windows/bin"
 

--- a/build-analyze.ps1
+++ b/build-analyze.ps1
@@ -6,7 +6,7 @@ git fetch --unshallow
 
 $SONAR_SERVER_URL = "https://sonarcloud.io"
 #$SONAR_TOKEN = # Access token coming from SonarCloud projet creation page. In this example, it is defined in the environement through a Github secret.
-$SONAR_SCANNER_VERSION = "5.0.1.3006" # Find the latest version in the "Windows" link on this page:
+$SONAR_SCANNER_VERSION = "8.0.1.6346" # Find the latest version in the "Windows" link on this page:
                                       # https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarscanner-cli/
 $BUILD_WRAPPER_OUT_DIR = "build_wrapper_output_directory" # Directory where build-wrapper output will be placed
 

--- a/build-analyze.ps1
+++ b/build-analyze.ps1
@@ -26,7 +26,7 @@ $env:Path += ";$HOME/.sonar/build-wrapper-win-x86"
 $path = "$HOME/.sonar/sonar-scanner-cli-$SONAR_SCANNER_VERSION-windows-x64.zip"
 (New-Object System.Net.WebClient).DownloadFile("https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-windows-x64.zip", $path)
 [System.IO.Compression.ZipFile]::ExtractToDirectory($path, "$HOME/.sonar")
-$env:Path += ";$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-windows/bin"
+$env:Path += ";$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-windows-x64/bin"
 
 # Setup the build system
 mkdir build


### PR DESCRIPTION
This PR updates GitHub Actions workflow dependencies and Sonar scan configuration.

Changes:
- Update `SonarSource/sonarqube-scan-action` and `install-build-wrapper` to `v7`
- Update `actions/checkout` to `v6`
- Normalize Sonar scan `args` formatting to match the updated example style
- Update additional workflow actions to current latest versions used in this repository
- Fix remaining `actionlint` findings